### PR TITLE
Initialize BuildNumber from debug information if not set

### DIFF
--- a/pkg/versioncheck/versioncheck.go
+++ b/pkg/versioncheck/versioncheck.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/armosec/utils-go/boolutils"
@@ -26,6 +27,15 @@ const CLIENT_ENV = "KS_CLIENT"
 
 var BuildNumber string
 var Client string
+
+func init() {
+	if BuildNumber == "" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+			BuildNumber = info.Main.Version
+		}
+	}
+}
+
 var LatestReleaseVersion string
 
 const UnknownBuildNumber = "unknown"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved initialization of version information to ensure build metadata is automatically captured from the runtime environment when not explicitly configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->