### PR TITLE
fix(versioncheck): normalize semver before comparison

### DIFF
--- a/pkg/versioncheck/versioncheck.go
+++ b/pkg/versioncheck/versioncheck.go
@@ -194,7 +194,10 @@ func (v *VersionCheckHandler) CheckLatestVersion(ctx context.Context, versionDat
 	LatestReleaseVersion = latestVersion.ClientUpdate
 
 	if latestVersion.ClientUpdate != "" {
-		if BuildNumber != "" && semver.Compare(BuildNumber, LatestReleaseVersion) == -1 {
+		if BuildNumber != "" && semver.Compare(
+			normalizeVersion(BuildNumber),
+			normalizeVersion(LatestReleaseVersion),
+		) == -1 {
 			logger.L().Ctx(ctx).Warning(warningMessage(LatestReleaseVersion))
 		}
 	}
@@ -209,6 +212,13 @@ func (v *VersionCheckHandler) CheckLatestVersion(ctx context.Context, versionDat
 	}
 
 	return nil
+}
+
+func normalizeVersion(v string) string {
+	if v != "" && !strings.HasPrefix(v, "v") {
+		return "v" + v
+	}
+	return v
 }
 
 func (v *VersionCheckHandler) getLatestVersion(versionData *VersionCheckRequest) (*VersionCheckResponse, error) {

--- a/pkg/versioncheck/versioncheck_test.go
+++ b/pkg/versioncheck/versioncheck_test.go
@@ -19,6 +19,27 @@ func TestCheckLatestVersion_Semver_Compare(t *testing.T) {
 
 }
 
+func TestNormalizeVersion(t *testing.T) {
+	assert.Equal(t, "v4.0.6", normalizeVersion("4.0.6"))
+	assert.Equal(t, "v3.0.15", normalizeVersion("v3.0.15"))
+	assert.Equal(t, "", normalizeVersion(""))
+}
+
+func TestSemverCompare_WithNormalization(t *testing.T) {
+	result := semver.Compare(
+		normalizeVersion("4.0.6"),
+		normalizeVersion("v3.0.15"),
+	)
+
+	assert.Equal(t, 1, result)
+}
+
+func TestSemverCompare_WithoutNormalization(t *testing.T) {
+	result := semver.Compare("4.0.6", "v3.0.15")
+
+	assert.Equal(t, -1, result)
+}
+
 func TestCheckLatestVersion(t *testing.T) {
 	type args struct {
 		ctx         context.Context


### PR DESCRIPTION
## Summary

Normalize semantic versions before calling `semver.Compare()` to avoid incorrect comparisons when `BuildNumber` does not contain a leading `v`.

Example:

```go
semver.Compare("4.0.6", "v3.0.15")
```

treats `"4.0.6"` as an invalid semantic version and incorrectly evaluates it as lower.

## Changes

* Added `normalizeVersion()` helper
* Normalized versions before comparison
* Added regression tests covering:

  * normalization behavior
  * mixed prefixed/non-prefixed comparisons
  * original invalid semver comparison case

## Testing

```bash
go test ./...
go test ./pkg/versioncheck -v
```

Fixes #48 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version comparison now consistently normalizes version formats before performing comparisons, improving reliability when checking against the latest release version.

* **Tests**
  * Added comprehensive unit tests validating version normalization and semver comparison behavior across different version string formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/backend/pull/49)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->