### PR TITLE
Raise client gRPC message cap to 128 MiB

### DIFF
--- a/pkg/client/v1/storageclient.go
+++ b/pkg/client/v1/storageclient.go
@@ -20,9 +20,15 @@ import (
 )
 
 // sbomStreamChunkSize is the per-chunk byte budget used by PutSBOMStream
-// and GetSBOMStream. Set well below the default 4 MiB gRPC message limit
+// and GetSBOMStream. Set well below the configured gRPC message limit
 // to leave headroom for framing overhead.
 const sbomStreamChunkSize = 1 << 20 // 1 MiB
+
+// maxGRPCMessageSize is the per-message cap configured on this client for
+// both send and receive. grpc-go defaults receive to 4 MiB; we raise it
+// so unary RPCs (e.g. GetProfile, SendContainerProfile) can carry larger
+// payloads. The server must be configured with at least the same limit.
+const maxGRPCMessageSize = 128 << 20 // 128 MiB
 
 // Default gRPC ports
 const (
@@ -215,6 +221,11 @@ func (c *StorageClient) Connect() error {
 		// Use insecure credentials
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
+
+	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(maxGRPCMessageSize),
+		grpc.MaxCallSendMsgSize(maxGRPCMessageSize),
+	))
 
 	conn, err := grpc.NewClient(c.address, dialOpts...)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `maxGRPCMessageSize = 128 << 20` constant in `pkg/client/v1/storageclient.go`.
- Applies `grpc.MaxCallRecvMsgSize` / `grpc.MaxCallSendMsgSize` via `grpc.WithDefaultCallOptions` in `Connect()`.

## Why
grpc-go defaults the receive cap to 4 MiB on both peers. Larger unary downloads (`GetProfile`, `GetContainerProfile`, `GetApplicationProfile`, etc.) fail at the client with `ResourceExhausted: received message larger than max`. Raising the client cap to 128 MiB lets those downloads complete.

Note: this is the client-side half. The storage server's own `MaxRecvMsgSize` must also be raised for large unary *uploads* to succeed — a companion change is going out on the cadashboardbe side.

Streaming RPCs (`PutSBOMStream`, `GetSBOMStream`, `SendContainerProfileStream`, `GetContainerProfileStream`) are unaffected; chunks remain 1 MiB.

## Test plan
- [ ] Existing unit tests pass (`go test ./pkg/client/v1/...`).
- [ ] Integration: with the matching server-side change deployed, exercise `GetContainerProfile` with a >4 MiB profile and confirm it no longer returns `ResourceExhausted`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage client now supports larger message sizes (up to 128 MiB) for improved data transfer capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/backend/pull/51)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->