### PR TITLE
test: make version-check test a robust live canary

### DIFF
--- a/pkg/versioncheck/versioncheck_test.go
+++ b/pkg/versioncheck/versioncheck_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,62 +82,37 @@ func TestCheckLatestVersion(t *testing.T) {
 }
 
 func TestVersionCheckHandler_getLatestVersion(t *testing.T) {
-	type fields struct {
-		versionURL string
-	}
-	type args struct {
-		versionData *VersionCheckRequest
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *VersionCheckResponse
-		wantErr bool
-	}{
-		{
-			name: "Get latest version",
-			fields: fields{
-				versionURL: "https://version-check.ks-services.co",
-			},
-			args: args{
-				versionData: &VersionCheckRequest{
-					Client: "kubescape",
-				},
-			},
-			want: &VersionCheckResponse{
-				Client:       "kubescape",
-				ClientUpdate: "v3.0.15",
-			},
-			wantErr: false,
-		},
-		{
-			name: "Failed to get latest version",
-			fields: fields{
-				versionURL: "https://example.com",
-			},
-			args: args{
-				versionData: &VersionCheckRequest{},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			v := &VersionCheckHandler{
-				versionURL: tt.fields.versionURL,
-			}
-			got, err := v.getLatestVersion(tt.args.versionData)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("VersionCheckHandler.getLatestVersion() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("VersionCheckHandler.getLatestVersion() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	t.Run("Get latest version", func(t *testing.T) {
+		// Live canary against the deployed version-check service. A request
+		// with an empty clientVersion MUST be told the latest version -- this
+		// guards the ksgf1v1 regression where empty/unparseable client
+		// versions silently received no clientUpdate. We assert a *valid*
+		// version rather than a hardcoded one so routine kubescape releases
+		// (which bump the reference) don't break this test.
+		v := &VersionCheckHandler{
+			versionURL: "https://version-check.ks-services.co",
+		}
+		got, err := v.getLatestVersion(&VersionCheckRequest{Client: "kubescape"})
+		if err != nil {
+			t.Fatalf("getLatestVersion() unexpected error = %v", err)
+		}
+		if got == nil {
+			t.Fatal("getLatestVersion() returned a nil response")
+		}
+		assert.Equal(t, "kubescape", got.Client)
+		assert.NotEmpty(t, got.ClientUpdate, "empty clientVersion must be told the latest version")
+		assert.True(t, semver.IsValid(normalizeVersion(got.ClientUpdate)),
+			"ClientUpdate %q must be a valid semantic version", got.ClientUpdate)
+	})
+
+	t.Run("Failed to get latest version", func(t *testing.T) {
+		v := &VersionCheckHandler{
+			versionURL: "https://example.com",
+		}
+		got, err := v.getLatestVersion(&VersionCheckRequest{})
+		assert.Error(t, err)
+		assert.Nil(t, got)
+	})
 }
 
 func TestGetTriggerSource(t *testing.T) {


### PR DESCRIPTION
## Problem

`TestVersionCheckHandler_getLatestVersion` probed the live version-check service with an empty `clientVersion` and asserted the response equaled **exactly `v3.0.15`**. That's brittle two ways:

1. It breaks whenever the latest kubescape release bumps past `3.0.15` — and `version-sync` auto-updates that reference from GitHub releases, so it *will* bump.
2. When a regression drops `clientUpdate` entirely (which just happened — see armosec/kubescape-usage#1), the failure reads `want v3.0.15, got empty` instead of a clear signal.

## Fix

Assert the actual **contract** rather than a hardcoded version:
- response is for the `kubescape` client, and
- `ClientUpdate` is a **non-empty, valid semantic version**.

This keeps the test useful as a **live canary** for the `ksgf1v1` version-check function — an empty `clientVersion` must be told the latest version — while surviving routine release bumps. Reuses the package's existing `golang.org/x/mod/semver` + `normalizeVersion` helper; no new dependency.

## Relationship to the current failure

This test currently **fails against the deployed service** because `ksgf1v1` has a live regression (empty/unparseable client versions get no `clientUpdate`). The root-cause fix is armosec/kubescape-usage#1. Once that function is redeployed, this canary goes green — and now stays green across version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)