### PR TITLE
KSCloudAPI client ignores caller context: GetExceptions and GetControlsInputs drop timeouts/cancellations

### DIFF
--- a/pkg/client/v1/kscloudapi.go
+++ b/pkg/client/v1/kscloudapi.go
@@ -222,8 +222,8 @@ func (api *KSCloudAPI) ListFrameworks() ([]string, error) {
 }
 
 // GetExceptions returns exception policies.
-func (api *KSCloudAPI) GetExceptions(clusterName string) ([]PostureExceptionPolicy, error) {
-	rdr, _, err := api.get(api.getExceptionsURL(clusterName))
+func (api *KSCloudAPI) GetExceptions(clusterName string, opts ...RequestOption) ([]PostureExceptionPolicy, error) {
+	rdr, _, err := api.get(api.getExceptionsURL(clusterName), opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -249,12 +249,12 @@ func (api *KSCloudAPI) getExceptionsURL(clusterName string) string {
 }
 
 // GetAccountConfig yields the account configuration.
-func (api *KSCloudAPI) GetAccountConfig(clusterName string) (*CustomerConfig, error) {
+func (api *KSCloudAPI) GetAccountConfig(clusterName string, opts ...RequestOption) (*CustomerConfig, error) {
 	if api.accountID == "" {
 		return &CustomerConfig{}, nil
 	}
 
-	rdr, _, err := api.get(api.getAccountConfig(clusterName))
+	rdr, _, err := api.get(api.getAccountConfig(clusterName), opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (api *KSCloudAPI) GetAccountConfig(clusterName string) (*CustomerConfig, er
 	accountConfig, err := utils.Decode[CustomerConfig](rdr)
 	if err != nil {
 		// retry with default scope
-		rdr, _, err = api.get(api.getAccountConfigDefault(clusterName))
+		rdr, _, err = api.get(api.getAccountConfigDefault(clusterName), opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -314,8 +314,8 @@ func (api *KSCloudAPI) getAccountConfigDefault(clusterName string) string {
 }
 
 // GetControlsInputs returns the controls inputs configured in the account configuration.
-func (api *KSCloudAPI) GetControlsInputs(clusterName string) (map[string][]string, error) {
-	accountConfig, err := api.GetAccountConfig(clusterName)
+func (api *KSCloudAPI) GetControlsInputs(clusterName string, opts ...RequestOption) (map[string][]string, error) {
+	accountConfig, err := api.GetAccountConfig(clusterName, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/v1/kscloudapi.go
+++ b/pkg/client/v1/kscloudapi.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -222,7 +223,13 @@ func (api *KSCloudAPI) ListFrameworks() ([]string, error) {
 }
 
 // GetExceptions returns exception policies.
-func (api *KSCloudAPI) GetExceptions(clusterName string, opts ...RequestOption) ([]PostureExceptionPolicy, error) {
+func (api *KSCloudAPI) GetExceptions(clusterName string) ([]PostureExceptionPolicy, error) {
+	return api.GetExceptionsWithContext(context.Background(), clusterName)
+}
+
+// GetExceptionsWithContext returns exception policies with the provided context.
+func (api *KSCloudAPI) GetExceptionsWithContext(ctx context.Context, clusterName string, opts ...RequestOption) ([]PostureExceptionPolicy, error) {
+	opts = append([]RequestOption{WithContext(ctx)}, opts...)
 	rdr, _, err := api.get(api.getExceptionsURL(clusterName), opts...)
 	if err != nil {
 		return nil, err
@@ -314,7 +321,13 @@ func (api *KSCloudAPI) getAccountConfigDefault(clusterName string) string {
 }
 
 // GetControlsInputs returns the controls inputs configured in the account configuration.
-func (api *KSCloudAPI) GetControlsInputs(clusterName string, opts ...RequestOption) (map[string][]string, error) {
+func (api *KSCloudAPI) GetControlsInputs(clusterName string) (map[string][]string, error) {
+	return api.GetControlsInputsWithContext(context.Background(), clusterName)
+}
+
+// GetControlsInputsWithContext returns the controls inputs configured in the account configuration with the provided context.
+func (api *KSCloudAPI) GetControlsInputsWithContext(ctx context.Context, clusterName string, opts ...RequestOption) (map[string][]string, error) {
+	opts = append([]RequestOption{WithContext(ctx)}, opts...)
 	accountConfig, err := api.GetAccountConfig(clusterName, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/client/v1/kscloudoption.go
+++ b/pkg/client/v1/kscloudoption.go
@@ -101,6 +101,13 @@ func WithHeaders(headers map[string]string) RequestOption {
 	}
 }
 
+// WithContext sets the context for the request
+func WithContext(ctx context.Context) RequestOption {
+	return func(o *RequestOptions) {
+		o.reqContext = ctx
+	}
+}
+
 // withTrace dumps requests for debugging
 func withTrace(enabled bool) RequestOption {
 	return func(o *RequestOptions) {

--- a/pkg/client/v1/vulnerabilities.go
+++ b/pkg/client/v1/vulnerabilities.go
@@ -1,16 +1,17 @@
 package v1
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/armosec/armoapi-go/armotypes"
-	"github.com/armosec/armoapi-go/identifiers"
-	httputils "github.com/armosec/utils-go/httputils"
-	v1 "github.com/kubescape/backend/pkg/server/v1"
-	"github.com/kubescape/backend/pkg/utils"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	v1 "github.com/kubescape/backend/pkg/server/v1"
+	"github.com/kubescape/backend/pkg/utils"
 )
 
 func constructCVEExceptionsURL(backendURL, customerGUID string, queryParams *url.Values) (*url.URL, error) {
@@ -40,13 +41,22 @@ func getCVEExceptionsURLByRawQuery(backendURL, customerGUID string, rawQuery *ur
 	return constructCVEExceptionsURL(backendURL, customerGUID, rawQuery)
 }
 
-func fetchCVEExceptions(url *url.URL, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+func fetchCVEExceptions(ctx context.Context, url *url.URL, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 	var vulnerabilityExceptionPolicy []armotypes.VulnerabilityExceptionPolicy
 
-	resp, err := httputils.HttpGet(http.DefaultClient, url.String(), headers)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("fetchCVEExceptions: resp.StatusCode %d", resp.StatusCode)
@@ -65,20 +75,20 @@ func fetchCVEExceptions(url *url.URL, headers map[string]string) ([]armotypes.Vu
 	return vulnerabilityExceptionPolicy, nil
 }
 
-func GetCVEExceptionByDesignator(backendURL, customerGUID string, designators *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+func GetCVEExceptionByDesignator(ctx context.Context, backendURL, customerGUID string, designators *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 	url, err := getCVEExceptionsURL(backendURL, customerGUID, designators)
 	if err != nil {
 		return nil, err
 	}
-	return fetchCVEExceptions(url, headers)
+	return fetchCVEExceptions(ctx, url, headers)
 }
 
-func GetCVEExceptionByRawQuery(backendURL, customerGUID string, rawQuery *url.Values, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+func GetCVEExceptionByRawQuery(ctx context.Context, backendURL, customerGUID string, rawQuery *url.Values, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 	url, err := getCVEExceptionsURLByRawQuery(backendURL, customerGUID, rawQuery)
 	if err != nil {
 		return nil, err
 	}
-	return fetchCVEExceptions(url, headers)
+	return fetchCVEExceptions(ctx, url, headers)
 }
 
 func GetVulnerabilitiesReportURL(eventReceiverUrl, customerGUID string) (*url.URL, error) {


### PR DESCRIPTION
# Description

Closes #56

The KSCloudAPI client in `github.com/kubescape/backend/pkg/client/v1` drops the caller's `context.Context`. Key endpoints like `GetExceptions`, `GetControlsInputs`, and `GetCVEExceptionByDesignator` take no context parameter, nor is there an exported `WithContext` RequestOption available to inject it.

Internally, `get()` and `post()` do eventually call `http.NewRequestWithContext(o.reqContext, ...)`, but `reqContext` is hardcoded to `context.Background()` with no way for a caller to override it.

As a result, two real fleet consumers are independently compensating for the same gap:

- `kubescape/core` explicitly drops its own context when adapting to `KSCloudAPI` (`core/cautils/getter/kscloudapi.go:31`) with a comment explaining that the upstream client isn't context-aware yet.
- `kubevuln` hits the same root cause through different call sites (`NewBaseReportSender`/`SendStatus`) and carries internal tracking issues (#446 and #450) and local `httpPostWithContext` workarounds.

## Impact

Any caller-supplied `ScanTimeout` or shutdown signal (SIGTERM) is silently ignored during these backend calls until the backend's internal 61s client timeout eventually fires. This prevents clean shutdowns and causes timeouts to be disregarded.

## Suggested Fix

Add `context.Context` parameters to `GetExceptions`, `GetControlsInputs`, and `GetCVEExceptionByDesignator` (or alternatively, expose an exported `WithContext` RequestOption). Thread the context into the existing `NewRequestWithContext` calls. Fixing this upstream will automatically resolve the workarounds needed in both `kubescape` and `kubevuln`.

## Testing / Proof of Missing Capability

To prove that the API client disregards caller contexts, we ran an isolated test against `v1.KSCloudAPI`'s `GetExceptions` endpoint locally.

**Testing Methodology:**

1. Spun up a mock HTTP server that intentionally delays its response by 1 full second.
2. Initialized `KSCloudAPI` pointing to the mock server.
3. Created a strict context with a `1 millisecond` timeout and deferred its cancellation.
4. Called `api.GetExceptions("my-cluster")` which should have respected the context and returned a `context.DeadlineExceeded` error almost instantly.

**Actual Results:** Because the function signature doesn't accept a context and internal calls fall back to `context.Background()`, the client completely ignored the 1ms timeout and blocked for the full 1-second duration of the HTTP call.

```text
$ go test -run TestGetExceptions_IgnoresContext -v ./pkg/client/v1
=== RUN   TestGetExceptions_IgnoresContext
    kscloudapi_timeout_test.go:44: Test proved that context was ignored. Time elapsed: 1.002961333s, Error: <nil>
--- PASS: TestGetExceptions_IgnoresContext (1.00s)
PASS
ok  	github.com/kubescape/backend/pkg/client/v1	2.043s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for attaching request contexts, allowing outgoing API requests to be cancelled or controlled.
  - Added request options to exception, account configuration, and controls input retrieval APIs.
  - Request options now apply consistently across fallback and delegated requests.

- **Improvements**
  - Vulnerability exception retrieval now supports context-aware request handling.
  - Existing error handling and fallback behavior are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->